### PR TITLE
Merging the constructor that takes "region" argument into the no-args co...

### DIFF
--- a/src/main/java/com/rmn/qa/aws/AwsVmManager.java
+++ b/src/main/java/com/rmn/qa/aws/AwsVmManager.java
@@ -88,16 +88,6 @@ public class AwsVmManager implements VmManager {
     public AwsVmManager() {
         awsProperties = initAWSProperties();
         this.region = awsProperties.getProperty("region");
-    }
-
-    /**
-     * Creates a new AwsVmManager instance.
-     *
-     * @param  region
-     */
-    public AwsVmManager(final String region) {
-        awsProperties = initAWSProperties();
-        this.region = region;
         /**
          * By default we use the credentials provided in the configuration files.
          * If there are none we fall back to IAM roles.

--- a/src/main/java/com/rmn/qa/aws/AwsVmManager.java
+++ b/src/main/java/com/rmn/qa/aws/AwsVmManager.java
@@ -262,6 +262,9 @@ public class AwsVmManager implements VmManager {
         throws NodesCouldNotBeStartedException {
         RunInstancesResult runInstancesResult;
         try {
+            if(client == null){
+                throw new RuntimeException("The client is not initialized");
+            }
             runInstancesResult = client.runInstances(request);
         } catch (AmazonServiceException e) {
 
@@ -340,6 +343,9 @@ public class AwsVmManager implements VmManager {
         TerminateInstancesRequest terminateRequest = new TerminateInstancesRequest();
         terminateRequest.withInstanceIds(instanceId);
 
+        if(client == null){
+            throw new RuntimeException("The client is not initialized");
+        }
         TerminateInstancesResult result = client.terminateInstances(terminateRequest);
         List<InstanceStateChange> stateChanges = result.getTerminatingInstances();
         boolean terminatedInstance = false;

--- a/src/test/java/com/rmn/qa/aws/VmManagerTest.java
+++ b/src/test/java/com/rmn/qa/aws/VmManagerTest.java
@@ -557,4 +557,36 @@ public class VmManagerTest {
         Assert.fail("Call should fail due to insufficient resources");
     }
 
+    @Test
+    //Tests that the client is initialized and exception is not thrown
+    public void testClientInitialized(){
+        AwsVmManager manageEC2 = new AwsVmManager();
+        String region = "east";
+        try{
+            manageEC2.launchNodes("foo", "bar", 4, "userData", false);
+        } catch(Exception e) {
+            Assert.assertFalse("The client should be initialized",e.getMessage().contains("The client is not initialized"));
+        }
+    }
+
+    @Test
+    //Tests that if the client is not initialized, an exception with appropriate message is thrown
+    public void testClientNotInitializedError(){
+        String accessKey = "foo",privateKey = "bar";
+        Properties properties = new Properties();
+        properties.setProperty(AutomationConstants.AWS_ACCESS_KEY,accessKey);
+        properties.setProperty(AutomationConstants.AWS_PRIVATE_KEY,privateKey);
+        String region = "east";
+
+        AwsVmManager manageEC2 = new AwsVmManager(null,properties,region);
+
+        try{
+            manageEC2.launchNodes("foo", "bar", 3, "userData", false);
+        } catch(Exception e) {
+            Assert.assertTrue("The client should be initialized", e.getMessage().contains("The client is not initialized"));
+            return;
+        }
+        Assert.fail("Exception should have been thrown for client not initialized");
+    }
+
 }


### PR DESCRIPTION
The no-args constructor in AwsVmManager is the one that is called by default by the servlet. However, that constructor does not intialize the client and the AWS credentials which is required to make connections with AWS. The constructor that takes "region" is not being used anywhere and assuming the region is passed through the properties file, we do not require that constructor. As part of this commit, the  constructor that takes region arg is removed and the code that initializes the client and credentials is moved to the no-arg/default constructor.