### PR TITLE
allow multiple security groups to be used when creating instances

### DIFF
--- a/src/main/java/com/rmn/qa/aws/AwsVmManager.java
+++ b/src/main/java/com/rmn/qa/aws/AwsVmManager.java
@@ -22,12 +22,7 @@ import java.io.InputStreamReader;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Properties;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -200,7 +195,14 @@ public class AwsVmManager implements VmManager {
         String securityGroupKey = awsProperties.getProperty(region + "_security_group");
         if (securityGroupKey != null) {
             log.info("Setting security group: " + securityGroupKey);
-            runRequest.withSecurityGroupIds(securityGroupKey);
+
+            String[] splitSecurityGroupdIds = securityGroupKey.split(",");
+
+            List aryLst = new ArrayList();
+            for (int i = 0; i < splitSecurityGroupdIds.length; i++) {
+                aryLst.add(splitSecurityGroupdIds[i]);
+            }
+            runRequest.setSecurityGroupIds(aryLst);
         }
 
         String keyName = awsProperties.getProperty(region + "_key_name");

--- a/src/main/java/com/rmn/qa/aws/AwsVmManager.java
+++ b/src/main/java/com/rmn/qa/aws/AwsVmManager.java
@@ -194,15 +194,16 @@ public class AwsVmManager implements VmManager {
 
         String securityGroupKey = awsProperties.getProperty(region + "_security_group");
         if (securityGroupKey != null) {
-            log.info("Setting security group: " + securityGroupKey);
 
             String[] splitSecurityGroupdIds = securityGroupKey.split(",");
 
-            List aryLst = new ArrayList();
+            List securityGroupIdsAryLst = new ArrayList();
             for (int i = 0; i < splitSecurityGroupdIds.length; i++) {
-                aryLst.add(splitSecurityGroupdIds[i]);
+
+                log.info("Setting security group(s): " + splitSecurityGroupdIds[i]);
+                securityGroupIdsAryLst.add(splitSecurityGroupdIds[i]);
             }
-            runRequest.setSecurityGroupIds(aryLst);
+            runRequest.setSecurityGroupIds(securityGroupIdsAryLst);
         }
 
         String keyName = awsProperties.getProperty(region + "_key_name");

--- a/src/test/java/com/rmn/qa/aws/VmManagerTest.java
+++ b/src/test/java/com/rmn/qa/aws/VmManagerTest.java
@@ -205,6 +205,13 @@ public class VmManagerTest {
         RunInstancesRequest request = client.getRunInstancesRequest();
         request.setSecurityGroupIds(securityGroupIdsAryLst);
         List<String> securityGroups = request.getSecurityGroupIds();
+        List<String> expectedSecurityGroups = Arrays.asList("securityGroup1,securityGroup2,securityGroup3".split(","));
+        Assert.assertTrue("Security groups should match all given security groups", securityGroups.containsAll(expectedSecurityGroups));
+
+        List<String> invalidSecurityGroups = Arrays.asList("securityGroup1,securityGroup2,securityGroup7".split(","));
+        Assert.assertFalse("Security groups should match only the set security groups", securityGroups.containsAll(invalidSecurityGroups));
+
+        Assert.assertFalse("Security group should not be empty", request.getSecurityGroupIds().isEmpty());
         Assert.assertEquals("More than 1 security group should be set",3,securityGroups.size());
     }
 


### PR DESCRIPTION
this change allows multiple security groups to be passed in aws.properties like this
us-west-2_security_group=sg-a7a342c8,sg-afa542c0,sg-cce342a3
Without this change if multiple security group is passed, it throws the error 
"Error trying to start nodes: com.amazonaws.AmazonServiceException: The parameter groupName cannot be used with the parameter subnet (Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameterCombination"