### PR TITLE
Fixing parse error thrown due toy google gson incompatibility

### DIFF
--- a/src/main/resources/nodeConfigTemplate.json
+++ b/src/main/resources/nodeConfigTemplate.json
@@ -11,7 +11,7 @@
             "maxInstances": <MAX_SESSION_CHROME>,
             "instanceId": "<INSTANCE_ID>",
             "seleniumProtocol": "WebDriver"
-        },
+        }
     ],
     "configuration":
     {


### PR DESCRIPTION
Selenium's new version moved from org.json to google gson. Upgrading to newer versions results in error parsing the nodeConfigTemplate.json. Fixing the json so it that it is a valid json which is compatible with gson.