### PR TITLE
Update default AMI image region prefixes

### DIFF
--- a/src/main/resources/aws.properties.default
+++ b/src/main/resources/aws.properties.default
@@ -14,12 +14,12 @@ ap-northeast-1_endpoint=https://ec2.ap-northeast-1.amazonaws.com
 sa-east-1_endpoint=https://ec2.sa-east-1.amazonaws.com
 
 # Node AMI Info
-east_linux_node_ami=ami-d216a3ba
+us-east-1_linux_node_ami=ami-d216a3ba
 node_instance_type_chrome=c3.large
 # Firefox and IE will only run in 1 browser per VM so we'll use micros for them
 node_instance_type_firefox=t2.micro
 node_instance_type_internetexplorer=t2.micro
-east_windows_node_ami=ami-dcd869b4
+us-east-1_windows_node_ami=ami-dcd869b4
 
 
 # Security Group Info


### PR DESCRIPTION
This is to correct an error when using the default aws.properties config. The region is set as us-east-1, but the AMI images were prefixed with 'east'. This caused a null to be returned from the getAmiIdForOs method in the AwsVmManager class, as that method returns the default region prefix as us-east-1, not east.